### PR TITLE
Fixes to allow releasing for jammy

### DIFF
--- a/do_release.py
+++ b/do_release.py
@@ -21,7 +21,7 @@ def main(workspace_path):
 
         for deb in debs:
             log.info("Adding {} to {}".format(deb, distro))
-            subprocess.run(
+            output = subprocess.run(
                 [
                     "reprepro",
                     "--basedir",
@@ -31,7 +31,16 @@ def main(workspace_path):
                     deb.resolve(),
                 ],
                 cwd=repo_path,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
             )
+            if (
+                output.returncode != 0
+                and "Already existing files can only be included again, if they are the same, but:"
+                not in output.stderr
+            ):
+                print(output.stderr)
 
     # Do the final export!
     subprocess.run(

--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -30,3 +30,11 @@ Architectures: amd64 arm64
 Components: main
 Description: Apt repository for the CoLTE community cellular project at UW
 SignWith: B2A72160B151CB88D84F6B24EA014307B38F63CC
+
+Origin: colte-archive
+Label: colte-archive
+Codename: jammy
+Architectures: amd64 arm64
+Components: main
+Description: Apt repository for the CoLTE community cellular project at UW
+SignWith: B2A72160B151CB88D84F6B24EA014307B38F63CC

--- a/repo/conf/distributions
+++ b/repo/conf/distributions
@@ -13,7 +13,7 @@ Codename: bionic
 Architectures: amd64 arm64
 Components: main
 Description: Apt repository for the CoLTE community cellular project at UW
-SignWith: B2A72160B151CB88D84F6B24EA014307B38F63CC 1ED66456DF2F145090D9E144DB21A5454D611150
+SignWith: B2A72160B151CB88D84F6B24EA014307B38F63CC
 
 Origin: colte-archive
 Label: colte-archive


### PR DESCRIPTION
A mixture of adding pieces for jammy that I missed in my last PR, and fixing problems with `do_release.py`. In particular:
- Add jammy to the reprepro distributions list.
- Remove the extra signing key from bionic. It's expired, so `reprepro` will fail to export.
- Capture the output of `reprepro includedeb`, and filter out the errors for adding non-identical files. The build process produces slightly different deb files every time, and we try to (re-)add every deb every time we run `do_release.py`. Thus, if you have a pre-existing repository, and are trying to add a couple new debs, most of the calls to `reprepro` will return an ignorable error. I considered setting it up to delete the old files and use the new ones, but decided to err on the side of not changing the published deb files if we don't have to.